### PR TITLE
Added in support for `Decimal` objects in SMTP API JSON messages

### DIFF
--- a/smtpapi/__init__.py
+++ b/smtpapi/__init__.py
@@ -1,5 +1,12 @@
-import json
+import json, decimal
 
+class _CustomJSONEncoder(json.JSONEncoder):
+
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return float(o)
+        # Provide a fallback to the default encoder if we haven't implemented special support for the object's class
+        return super(_CustomJSONEncoder, self).default(o)
 
 class SMTPAPIHeader(object):
 
@@ -88,4 +95,4 @@ class SMTPAPIHeader(object):
         for key in self.data.keys():
             if self.data[key] != [] and self.data[key] != {}:
                 result[key] = self.data[key]
-        return json.dumps(result)
+        return json.dumps(result, cls=_CustomJSONEncoder)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,14 +1,12 @@
-import unittest
-import json
+import unittest, json, decimal
 from smtpapi import SMTPAPIHeader
-
 
 class TestSMTPAPI(unittest.TestCase):
 
     def setUp(self):
         self.validHeader = json.loads('''{"to":["test@email.com",
         "test2@email.com", "test3@email.com"],
-        "sub":{"subKey":["subValue"]},
+        "sub":{"subKey":["subValue"],"decimalKey":[1.23456789]},
         "section":{"testSection":"sectionValue"},
         "category":["testCategory"],
         "unique_args":{"testUnique":"uniqueValue"},
@@ -19,7 +17,7 @@ class TestSMTPAPI(unittest.TestCase):
         "filters":{"testFilter":{"settings":{"filter":"filterValue"}}}}''')
 
         self.dropsHeader = json.loads('''{
-        "sub":{"subKey":["subValue"]},
+        "sub":{"subKey":["subValue"],"decimalKey":[1.23456789]},
         "unique_args":{"testUnique":"uniqueValue"},
         "filters":{"testFilter":{"settings":{"filter":"filterValue"}}}}''')
 
@@ -28,6 +26,7 @@ class TestSMTPAPI(unittest.TestCase):
         header.add_to('test@email.com')
         header.add_to(['test2@email.com', 'test3@email.com'])
         header.add_substitution('subKey', 'subValue')
+        header.add_substitution('decimalKey', decimal.Decimal("1.23456789"))
         header.add_section('testSection', 'sectionValue')
         header.add_category('testCategory')
         header.add_unique_arg('testUnique', 'uniqueValue')
@@ -42,7 +41,10 @@ class TestSMTPAPI(unittest.TestCase):
     def test_set(self):
         header = SMTPAPIHeader()
         header.set_tos(["test@email.com", "test2@email.com", "test3@email.com"])
-        header.set_substitutions(json.loads('{"subKey":["subValue"]}'))
+        header.set_substitutions({
+            "subKey": ["subValue"],
+            "decimalKey": [decimal.Decimal("1.23456789")]
+        })
         header.set_sections(json.loads('{"testSection":"sectionValue"}'))
         header.set_categories(["testCategory"])
         header.set_unique_args(json.loads('{"testUnique":"uniqueValue"}'))
@@ -56,7 +58,10 @@ class TestSMTPAPI(unittest.TestCase):
     def test_drop_empty(self):
         header = SMTPAPIHeader()
         header.set_tos([])
-        header.set_substitutions(json.loads('{"subKey":["subValue"]}'))
+        header.set_substitutions({
+            "subKey": ["subValue"],
+            "decimalKey": [decimal.Decimal("1.23456789")]
+        })
         header.set_sections(json.loads('{}'))
         header.set_categories([])
         header.set_unique_args(json.loads('{"testUnique":"uniqueValue"}'))


### PR DESCRIPTION
Added a custom `json.JSONEncoder` class, `_CustomJSONEncoder`, to allow for `decimal.Decimal` objects to be sent as values in SMTP API JSON messages (for example, when setting substitutions). Also updated `TestSMTPAPI` to test this feature. Changes made to address issue #7.